### PR TITLE
dev -> Staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# macOS
+.DS_Store
+
+# Archivos temporales de Office y editores
+~$*
+*.tmp
+*.swp
+
+# Node/VSCode
+node_modules/
+.vscode/
+
+# Exportados temporales
+*.log


### PR DESCRIPTION
Se agrega gitignore para omitir:
- `.DS_Store (mac)`
- Archivos temporales
- node_modules
- archivos log `*.log`